### PR TITLE
release v0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 ## [Unreleased]
 
 
+<a name="v0.0.6"></a>
+## [v0.0.6] - 2022-10-01
+### Chore
+- generate changelog
+- update to v0.0.6
+- add "reverie-util" to workspace
+- upgrade rust edition to 2021
+- changelog
+
+### Docs
+- changelog
+
+### Reverts
+- no longer support macos
+- remove macos
+
+### Pull Requests
+- Merge pull request [#82](https://github.com/yuma140902/Reverie/issues/82) from yuma140902/changelog
+- Merge pull request [#79](https://github.com/yuma140902/Reverie/issues/79) from yuma140902/reverie-util
+- Merge pull request [#76](https://github.com/yuma140902/Reverie/issues/76) from yuma140902/re-export-types
+- Merge pull request [#72](https://github.com/yuma140902/Reverie/issues/72) from yuma140902/window-builder-maximize
+- Merge pull request [#71](https://github.com/yuma140902/Reverie/issues/71) from yuma140902/high-dpi
+- Merge pull request [#70](https://github.com/yuma140902/Reverie/issues/70) from yuma140902/handle-resize
+- Merge pull request [#65](https://github.com/yuma140902/Reverie/issues/65) from yuma140902/in-game-manual
+- Merge pull request [#61](https://github.com/yuma140902/Reverie/issues/61) from yuma140902/block-destroy
+- Merge pull request [#60](https://github.com/yuma140902/Reverie/issues/60) from yuma140902/clamp-pitch
+- Merge pull request [#59](https://github.com/yuma140902/Reverie/issues/59) from yuma140902/collision
+- Merge pull request [#58](https://github.com/yuma140902/Reverie/issues/58) from yuma140902/color-vao
+- Merge pull request [#56](https://github.com/yuma140902/Reverie/issues/56) from yuma140902/multi-renderer
+- Merge pull request [#57](https://github.com/yuma140902/Reverie/issues/57) from yuma140902/craft-is-yagami-craft
+- Merge pull request [#49](https://github.com/yuma140902/Reverie/issues/49) from yuma140902/yagami-craft
+- Merge pull request [#47](https://github.com/yuma140902/Reverie/issues/47) from yuma140902/generic-deg-rad
+- Merge pull request [#46](https://github.com/yuma140902/Reverie/issues/46) from yuma140902/mouse
+- Merge pull request [#44](https://github.com/yuma140902/Reverie/issues/44) from yuma140902/fix-feature-cfg
+- Merge pull request [#43](https://github.com/yuma140902/Reverie/issues/43) from yuma140902/keyinput
+- Merge pull request [#40](https://github.com/yuma140902/Reverie/issues/40) from yuma140902/deg-rad
+- Merge pull request [#38](https://github.com/yuma140902/Reverie/issues/38) from yuma140902/derive-debug
+- Merge pull request [#37](https://github.com/yuma140902/Reverie/issues/37) from yuma140902/clippy
+- Merge pull request [#36](https://github.com/yuma140902/Reverie/issues/36) from yuma140902/github-actions-cargo
+- Merge pull request [#34](https://github.com/yuma140902/Reverie/issues/34) from yuma140902/window-builder
+- Merge pull request [#33](https://github.com/yuma140902/Reverie/issues/33) from yuma140902/cargo-workspace
+- Merge pull request [#32](https://github.com/yuma140902/Reverie/issues/32) from yuma140902/example-craft
+- Merge pull request [#28](https://github.com/yuma140902/Reverie/issues/28) from yuma140902/example-raw
+
+
 <a name="v0.0.5"></a>
 ## [v0.0.5] - 2022-08-26
 ### Chore
@@ -57,7 +102,8 @@
 <a name="v0.0.0"></a>
 ## v0.0.0 - 2021-10-04
 
-[Unreleased]: https://github.com/yuma140902/Reverie/compare/v0.0.5...HEAD
+[Unreleased]: https://github.com/yuma140902/Reverie/compare/v0.0.6...HEAD
+[v0.0.6]: https://github.com/yuma140902/Reverie/compare/v0.0.5...v0.0.6
 [v0.0.5]: https://github.com/yuma140902/Reverie/compare/v0.0.4...v0.0.5
 [v0.0.4]: https://github.com/yuma140902/Reverie/compare/0.0.3...v0.0.4
 [0.0.3]: https://github.com/yuma140902/Reverie/compare/v0.0.2...0.0.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 
 members = [
   "reverie",
+  "reverie-util",
   "examples/*"
 ]
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A toy game engine
 
 See [CHANGELOG.md](./CHANGELOG.md).
 
-Install [git-chglog](https://github.com/git-chglog/git-chglog) and run `git-chglog --output CHANGELOG.md`.
+Install [git-chglog](https://github.com/git-chglog/git-chglog) and run `git-chglog --output CHANGELOG.md --next-tag <NEXT TAG>`.
 
 ### Commit message
 

--- a/examples/craft/Cargo.toml
+++ b/examples/craft/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-reverie-engine = { version = "0.0.5", path = "../../reverie" }
+reverie-engine = { path = "../../reverie" }
 nalgebra = { version = "0.31.1", features = ["serde-serialize"] }
 nalgebra-glm = "0.17.0"
 c_str_macro = "1.0.3"

--- a/examples/raw/Cargo.toml
+++ b/examples/raw/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2018"
 
 [dependencies]
 c_str_macro = "1.0.3"
-reverie-engine = { version = "0.0.5", path = "../../reverie" }
+reverie-engine = { path = "../../reverie" }

--- a/examples/window/Cargo.toml
+++ b/examples/window/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-reverie-engine = { version = "0.0.5", path = "../../reverie" }
+reverie-engine = { path = "../../reverie" }

--- a/reverie/Cargo.toml
+++ b/reverie/Cargo.toml
@@ -2,7 +2,7 @@
 name = "reverie-engine"
 version = "0.0.5"
 license = "MPL-2.0"
-edition = "2018"
+edition = "2021"
 authors  = ["yuma140902 <yuma140902@gmail.com>"]
 description = "A toy game engine"
 readme = "README.md"

--- a/reverie/Cargo.toml
+++ b/reverie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reverie-engine"
-version = "0.0.5"
+version = "0.0.6"
 license = "MPL-2.0"
 edition = "2021"
 authors  = ["yuma140902 <yuma140902@gmail.com>"]


### PR DESCRIPTION
- chore: upgrade rust edition to 2021
- chore: add "reverie-util" to workspace
- chore: update to v0.0.6
- chore: generate changelog
- docs: update readme
