### PR TITLE
fix clippy nursery errors

### DIFF
--- a/examples/opengl/craft/src/collision.rs
+++ b/examples/opengl/craft/src/collision.rs
@@ -11,7 +11,7 @@ pub fn modify_velocity(
     entity_velocity: &mut Vector3,
     entity_bounding_box: &Cuboid,
     entity_pos: &Point3,
-    world_aabbs: &Vec<Aabb>,
+    world_aabbs: &[Aabb],
 ) {
     let entity_aabb =
         entity_bounding_box.aabb(&Isometry3::new(entity_pos.coords, Vector3::zeros()));
@@ -39,8 +39,8 @@ pub fn modify_velocity(
 }
 
 fn modify<'a>(
-    world_aabbs: &Vec<Aabb>,
-    extended_aabbs: &Vec<Aabb>,
+    world_aabbs: &[Aabb],
+    extended_aabbs: &[Aabb],
     entity_pos: &Point3,
     entity_velocity: &mut Vector3,
     entity_aabb: &Aabb,

--- a/examples/opengl/craft/src/collision.rs
+++ b/examples/opengl/craft/src/collision.rs
@@ -51,7 +51,7 @@ fn modify<'a>(
         entity_aabb.half_extents(),
     ));
 
-    let mut nearest_toi = std::f32::INFINITY;
+    let mut nearest_toi = f32::INFINITY;
     let mut nearest_normal: Option<Vector3> = None;
     for (aabb, extended_aabb) in world_aabbs.iter().zip(extended_aabbs.iter()) {
         // エンティティが対象のAABBの中にいるときは当たり判定を行わない

--- a/examples/opengl/craft/src/collision.rs
+++ b/examples/opengl/craft/src/collision.rs
@@ -38,7 +38,7 @@ pub fn modify_velocity(
     ) {}
 }
 
-fn modify<'a>(
+fn modify(
     world_aabbs: &[Aabb],
     extended_aabbs: &[Aabb],
     entity_pos: &Point3,

--- a/examples/opengl/craft/src/collision.rs
+++ b/examples/opengl/craft/src/collision.rs
@@ -77,10 +77,8 @@ fn modify<'a>(
     }
 
     // 壁ずりベクトルを求める
-    if let Some(nearest_normal) = nearest_normal {
+    nearest_normal.map_or(false, |nearest_normal| {
         *entity_velocity -= nearest_normal * entity_velocity.dot(&nearest_normal);
         true
-    } else {
-        false
-    }
+    })
 }

--- a/examples/opengl/craft/src/main.rs
+++ b/examples/opengl/craft/src/main.rs
@@ -40,7 +40,7 @@ fn main() {
     let height = 480;
 
     let config = CONFIG.get_or_init(|| {
-        let string = std::fs::read_to_string(CONFIG_FILE).unwrap_or("{}".to_string());
+        let string = std::fs::read_to_string(CONFIG_FILE).unwrap_or_else(|_| "{}".to_string());
         serde_json::from_str(&string).unwrap_or_default()
     });
     println!("{:?}", config);

--- a/examples/opengl/craft/src/raycast.rs
+++ b/examples/opengl/craft/src/raycast.rs
@@ -14,7 +14,7 @@ pub enum Side {
 }
 
 impl Side {
-    pub fn offset(&self, x: u32, y: u32, z: u32) -> (u32, u32, u32) {
+    pub const fn offset(&self, x: u32, y: u32, z: u32) -> (u32, u32, u32) {
         match self {
             Self::Top => (x, y + 1, z),
             Self::Bottom => {

--- a/examples/opengl/craft/src/raycast.rs
+++ b/examples/opengl/craft/src/raycast.rs
@@ -50,7 +50,7 @@ pub fn hit_block_and_side(player: &Player, world: &World) -> Option<(u32, u32, u
         math::calc_front_right_up(player.camera.yaw(), player.camera.pitch());
     let ray = Ray::new(eye_pos, front);
 
-    let mut nearest_toi = std::f32::INFINITY;
+    let mut nearest_toi = f32::INFINITY;
     let mut nearest_xyzside = None;
     for (x, y, z, aabb) in world.generate_selection_aabbs().iter() {
         // プレイヤーがブロックに埋まっているとき
@@ -90,7 +90,7 @@ pub fn hit_block(player: &Player, world: &World) -> Option<(u32, u32, u32)> {
         math::calc_front_right_up(player.camera.yaw(), player.camera.pitch());
     let ray = Ray::new(eye_pos, front);
 
-    let mut nearest_toi = std::f32::INFINITY;
+    let mut nearest_toi = f32::INFINITY;
     let mut nearest_xyz = None;
     for (x, y, z, aabb) in world.generate_selection_aabbs().iter() {
         // プレイヤーがブロックに埋まっているとき

--- a/examples/opengl/craft/src/world.rs
+++ b/examples/opengl/craft/src/world.rs
@@ -18,7 +18,7 @@ pub struct World {
     blocks: [bool; 16 * 16 * 16],
 }
 
-fn pos_to_index(x: u32, y: u32, z: u32) -> usize {
+const fn pos_to_index(x: u32, y: u32, z: u32) -> usize {
     (16 * 16 * y + 16 * z + x) as usize
 }
 
@@ -33,7 +33,7 @@ fn get_block_aabb(x: u32, y: u32, z: u32) -> Aabb {
 }
 
 impl World {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             blocks: [false; 16 * 16 * 16],
         }

--- a/examples/opengl/craft/src/world.rs
+++ b/examples/opengl/craft/src/world.rs
@@ -77,6 +77,7 @@ impl World {
         v
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn generate_vertex_obj<'a>(
         &self,
         gl: &Gl,

--- a/reverie-engine-opengl/src/camera.rs
+++ b/reverie-engine-opengl/src/camera.rs
@@ -64,7 +64,12 @@ impl Camera {
     }
 
     pub fn projection_matrix(&self, width: u32, height: u32) -> Matrix4<f32> {
-        Matrix4::new_perspective(width as f32 / height as f32, self.fov.to_rad().into(), 0.1, 100.0)
+        Matrix4::new_perspective(
+            width as f32 / height as f32,
+            self.fov.to_rad().into(),
+            0.1,
+            100.0,
+        )
     }
 
     pub fn set_pos(&mut self, pos: Point3<f32>) {
@@ -95,19 +100,19 @@ impl Camera {
         self.fov = fov;
     }
 
-    pub fn pos(&self) -> Point3<f32> {
+    pub const fn pos(&self) -> Point3<f32> {
         self.pos
     }
 
-    pub fn yaw(&self) -> Rad<f32> {
+    pub const fn yaw(&self) -> Rad<f32> {
         self.yaw
     }
 
-    pub fn pitch(&self) -> Rad<f32> {
+    pub const fn pitch(&self) -> Rad<f32> {
         self.pitch
     }
 
-    pub fn fov(&self) -> Deg<f32> {
+    pub const fn fov(&self) -> Deg<f32> {
         self.fov
     }
 }

--- a/reverie-engine-opengl/src/engine.rs
+++ b/reverie-engine-opengl/src/engine.rs
@@ -10,11 +10,11 @@ impl Default for ReverieEngine {
 }
 
 impl ReverieEngine {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {}
     }
 
-    pub fn window_builder(&self) -> WindowBuilder {
+    pub const fn window_builder(&self) -> WindowBuilder {
         WindowBuilder::new()
     }
 

--- a/reverie-engine-opengl/src/gl.rs
+++ b/reverie-engine-opengl/src/gl.rs
@@ -4,8 +4,8 @@
 //!
 //! 機能拡張は無し
 
-#![allow(clippy::all)]
-
+#[allow(clippy::all)]
+#[allow(clippy::nursery)]
 mod bindings {
     include!(concat!(env!("OUT_DIR"), "/gl_bindings.rs"));
 }

--- a/reverie-engine-opengl/src/gui/layout.rs
+++ b/reverie-engine-opengl/src/gui/layout.rs
@@ -28,7 +28,7 @@ pub enum Origin {
 }
 
 impl Origin {
-    pub fn x_diff(&self, width: u32) -> i32 {
+    pub const fn x_diff(&self, width: u32) -> i32 {
         use Origin::*;
         match *self {
             TopLeft | Left | BottomLeft => 0,
@@ -37,7 +37,7 @@ impl Origin {
         }
     }
 
-    pub fn y_diff(&self, height: u32) -> i32 {
+    pub const fn y_diff(&self, height: u32) -> i32 {
         use Origin::*;
         match *self {
             TopLeft | Top | TopRight => 0,
@@ -55,7 +55,7 @@ pub enum Position<T> {
 }
 
 impl Position<i32> {
-    pub fn actual_value(&self, max: i32) -> i32 {
+    pub const fn actual_value(&self, max: i32) -> i32 {
         match *self {
             Self::Positive(distance) => distance,
             Self::Center(distance) => max / 2_i32 + distance,
@@ -69,7 +69,7 @@ where
     T: PartialEq,
     U: PartialEq,
 {
-    pub fn new(origin_x: T, origin_y: T, width: U, height: U) -> Self {
+    pub const fn new(origin_x: T, origin_y: T, width: U, height: U) -> Self {
         Self {
             origin_x,
             origin_y,
@@ -78,19 +78,19 @@ where
         }
     }
 
-    pub fn origin_x(&self) -> &T {
+    pub const fn origin_x(&self) -> &T {
         &self.origin_x
     }
 
-    pub fn origin_y(&self) -> &T {
+    pub const fn origin_y(&self) -> &T {
         &self.origin_y
     }
 
-    pub fn width(&self) -> &U {
+    pub const fn width(&self) -> &U {
         &self.width
     }
 
-    pub fn height(&self) -> &U {
+    pub const fn height(&self) -> &U {
         &self.height
     }
 }

--- a/reverie-engine-opengl/src/shader.rs
+++ b/reverie-engine-opengl/src/shader.rs
@@ -58,6 +58,15 @@ impl Program {
             let error = create_whitespace_cstring_with_len(len as usize);
 
             unsafe {
+                // as_ptr() の戻り値へ書き込むのは未定義動作である (as_mut_ptr()は用意されていない)
+                //
+                // > The returned pointer is read-only; writing to it (including passing it to C code that writes to it) causes undefined behavior.
+                // https://doc.rust-lang.org/std/ffi/struct.CString.html#method.as_ptr
+                //
+                // でも動いているのでとりあえずそのまま使う。
+                // glow にもそういうコードがある。
+                // https://github.com/grovesNL/glow/blob/eb44a878a756d5ddce8505158690ec9bd272be8f/src/native.rs#L422
+                #[allow(clippy::as_ptr_cast_mut)]
                 gl.GetProgramInfoLog(
                     program_id,
                     len,
@@ -210,6 +219,15 @@ impl Shader {
 
             let error = create_whitespace_cstring_with_len(len as usize);
             unsafe {
+                // as_ptr() の戻り値へ書き込むのは未定義動作である (as_mut_ptr()は用意されていない)
+                //
+                // > The returned pointer is read-only; writing to it (including passing it to C code that writes to it) causes undefined behavior.
+                // https://doc.rust-lang.org/std/ffi/struct.CString.html#method.as_ptr
+                //
+                // でも動いているのでとりあえずそのまま使う。
+                // glow にもそういうコードがある。
+                // https://github.com/grovesNL/glow/blob/eb44a878a756d5ddce8505158690ec9bd272be8f/src/native.rs#L333
+                #[allow(clippy::as_ptr_cast_mut)]
                 gl.GetShaderInfoLog(id, len, std::ptr::null_mut(), error.as_ptr() as *mut GLchar);
             }
 

--- a/reverie-engine-opengl/src/shader.rs
+++ b/reverie-engine-opengl/src/shader.rs
@@ -90,6 +90,8 @@ impl Program {
         }
     }
 
+    #[allow(clippy::missing_safety_doc)]
+    // TODO: Safetyの説明を書く
     /// ユニフォーム変数を送る
     pub unsafe fn set_uniforms(&self, uniforms: &UniformVariables<'_>) {
         for (name, uniform) in uniforms.map.iter() {
@@ -97,6 +99,8 @@ impl Program {
         }
     }
 
+    #[allow(clippy::missing_safety_doc)]
+    // TODO: Safetyの説明を書く
     /// ユニフォーム変数を送る
     pub unsafe fn set_uniform(&self, name: &CStr, value: &Uniform<'_>) {
         match *value {
@@ -109,6 +113,8 @@ impl Program {
         }
     }
 
+    #[allow(clippy::missing_safety_doc)]
+    // TODO: Safetyの説明を書く
     /// bool型のユニフォーム変数を送る
     pub unsafe fn set_bool(&self, name: &CStr, value: bool) {
         self.gl.Uniform1i(
@@ -117,18 +123,24 @@ impl Program {
         );
     }
 
+    #[allow(clippy::missing_safety_doc)]
+    // TODO: Safetyの説明を書く
     /// int型のユニフォーム変数を送る
     pub unsafe fn set_int(&self, name: &CStr, value: i32) {
         self.gl
             .Uniform1i(self.gl.GetUniformLocation(self.id, name.as_ptr()), value);
     }
 
+    #[allow(clippy::missing_safety_doc)]
+    // TODO: Safetyの説明を書く
     /// float型のユニフォーム変数を送る
     pub unsafe fn set_float(&self, name: &CStr, value: f32) {
         self.gl
             .Uniform1f(self.gl.GetUniformLocation(self.id, name.as_ptr()), value);
     }
 
+    #[allow(clippy::missing_safety_doc)]
+    // TODO: Safetyの説明を書く
     /// 3次元ベクトル型(float)のユニフォーム変数を送る
     pub unsafe fn set_vector3(&self, name: &CStr, value: &nalgebra::Vector3<f32>) {
         self.gl.Uniform3fv(
@@ -138,12 +150,16 @@ impl Program {
         );
     }
 
+    #[allow(clippy::missing_safety_doc)]
+    // TODO: Safetyの説明を書く
     /// float型のユニフォーム変数3つを送る
     pub unsafe fn set_vec3(&self, name: &CStr, x: f32, y: f32, z: f32) {
         self.gl
             .Uniform3f(self.gl.GetUniformLocation(self.id, name.as_ptr()), x, y, z);
     }
 
+    #[allow(clippy::missing_safety_doc)]
+    // TODO: Safetyの説明を書く
     /// 4次行列型(float)のユニフォーム変数を送る
     pub unsafe fn set_mat4(&self, name: &CStr, mat: &nalgebra::Matrix4<f32>) {
         self.gl.UniformMatrix4fv(

--- a/reverie-engine-opengl/src/shader.rs
+++ b/reverie-engine-opengl/src/shader.rs
@@ -303,7 +303,7 @@ impl<'a> Default for UniformVariables<'a> {
 
 impl<'a> UniformVariables<'a> {
     /// 空のセットを作る
-    pub fn new() -> UniformVariables<'a> {
+    pub fn new() -> Self {
         Self {
             map: HashMap::new(),
         }

--- a/reverie-engine-opengl/src/shader.rs
+++ b/reverie-engine-opengl/src/shader.rs
@@ -79,7 +79,7 @@ impl Program {
     ///
     /// # Safety
     /// glDeleteProgramされていない限り安全
-    pub unsafe fn raw_id(&self) -> GLuint {
+    pub const unsafe fn raw_id(&self) -> GLuint {
         self.id
     }
 
@@ -111,8 +111,10 @@ impl Program {
 
     /// bool型のユニフォーム変数を送る
     pub unsafe fn set_bool(&self, name: &CStr, value: bool) {
-        self.gl
-            .Uniform1i(self.gl.GetUniformLocation(self.id, name.as_ptr()), value as i32);
+        self.gl.Uniform1i(
+            self.gl.GetUniformLocation(self.id, name.as_ptr()),
+            value as i32,
+        );
     }
 
     /// int型のユニフォーム変数を送る
@@ -241,7 +243,7 @@ impl Shader {
     ///
     /// # Safety
     /// glDeleteShaderされていない限り安全
-    pub unsafe fn raw_id(&self) -> GLuint {
+    pub const unsafe fn raw_id(&self) -> GLuint {
         self.id
     }
 }
@@ -286,7 +288,9 @@ impl<'a> Default for UniformVariables<'a> {
 impl<'a> UniformVariables<'a> {
     /// 空のセットを作る
     pub fn new() -> UniformVariables<'a> {
-        Self { map: HashMap::new() }
+        Self {
+            map: HashMap::new(),
+        }
     }
 
     /// 名前を指定してユニフォーム変数を追加する

--- a/reverie-engine-opengl/src/shader.rs
+++ b/reverie-engine-opengl/src/shader.rs
@@ -275,7 +275,7 @@ impl Drop for Shader {
 
 fn create_whitespace_cstring_with_len(len: usize) -> CString {
     let mut buffer: Vec<u8> = Vec::with_capacity(len + 1);
-    buffer.extend([b' '].iter().cycle().take(len));
+    buffer.extend(std::iter::once(b' ').cycle().take(len));
     unsafe { CString::from_vec_unchecked(buffer) }
 }
 

--- a/reverie-engine-opengl/src/texture/image_manager.rs
+++ b/reverie-engine-opengl/src/texture/image_manager.rs
@@ -138,7 +138,7 @@ impl<'a> ImageLoadInfo<'a> {
     ///
     /// # Safety
     /// OpenGLにテクスチャ読み込まれている限り安全
-    pub unsafe fn raw_gl_id(&self) -> u32 {
+    pub const unsafe fn raw_gl_id(&self) -> u32 {
         self.gl_id
     }
 }

--- a/reverie-engine-opengl/src/texture/texture_atlas.rs
+++ b/reverie-engine-opengl/src/texture/texture_atlas.rs
@@ -12,7 +12,7 @@ pub struct TextureUV<Width, Height, AtlasWidth, AtlasHeight> {
     pub begin_v: f32,
     pub end_u: f32,
     pub end_v: f32,
-    _pd: PhantomData<fn() -> (Width, Height, AtlasWidth, AtlasHeight)>,
+    _pd: PhantomData<(Width, Height, AtlasWidth, AtlasHeight)>,
 }
 
 impl<Width, Height, AtlasWidth, AtlasHeight> TextureUV<Width, Height, AtlasWidth, AtlasHeight> {

--- a/reverie-engine-opengl/src/vao.rs
+++ b/reverie-engine-opengl/src/vao.rs
@@ -38,13 +38,10 @@ pub struct Vao<'a> {
 
 impl<'a> Vao<'a> {
     #[allow(clippy::too_many_arguments)]
-    #[deprecated(note = "Use `self::vao_buffer::VaoBuffer` instead", since = "0.0.8")]
-    /// 代わりに[`self::vao_buffer::VaoBuffer`]を使うことを推奨
-    ///
     /// ## Safety
     ///
     /// `data` が有効なポインタであること
-    pub unsafe fn new(
+    unsafe fn new(
         gl: Gl,
         size: GLsizeiptr,
         data: *const c_void,
@@ -100,9 +97,7 @@ impl<'a> Vao<'a> {
         }
     }
 
-    #[deprecated(note = "Use `crate::Renderer` instead", since = "0.0.8")]
-    /// Use [`crate::Renderer`] instead
-    pub fn draw(&self, _uniforms: &UniformVariables, draw_mode: GLenum) {
+    fn draw(&self, _uniforms: &UniformVariables, draw_mode: GLenum) {
         unsafe {
             if self.config.depth_test {
                 self.gl.Enable(gl::DEPTH_TEST);
@@ -136,10 +131,8 @@ impl<'a> Vao<'a> {
         }
     }
 
-    #[deprecated(note = "Use `crate::Renderer` instead", since = "0.0.8")]
     /// ポリゴンを描画する
-    /// Use [`crate::Renderer`] instead
-    pub fn draw_triangles(&self, uniforms: &UniformVariables) {
+    fn draw_triangles(&self, uniforms: &UniformVariables) {
         self.draw(uniforms, gl::TRIANGLES);
     }
 }

--- a/reverie-engine-opengl/src/vao.rs
+++ b/reverie-engine-opengl/src/vao.rs
@@ -40,7 +40,11 @@ impl<'a> Vao<'a> {
     #[allow(clippy::too_many_arguments)]
     #[deprecated(note = "Use `self::vao_buffer::VaoBuffer` instead", since = "0.0.8")]
     /// 代わりに[`self::vao_buffer::VaoBuffer`]を使うことを推奨
-    pub fn new(
+    ///
+    /// ## Safety
+    ///
+    /// `data` が有効なポインタであること
+    pub unsafe fn new(
         gl: Gl,
         size: GLsizeiptr,
         data: *const c_void,

--- a/reverie-engine-opengl/src/vao.rs
+++ b/reverie-engine-opengl/src/vao.rs
@@ -37,6 +37,8 @@ pub struct Vao<'a> {
 }
 
 impl<'a> Vao<'a> {
+    #[allow(clippy::too_many_arguments)]
+    #[deprecated(note = "Use `self::vao_buffer::VaoBuffer` instead", since = "0.0.8")]
     /// 代わりに[`self::vao_buffer::VaoBuffer`]を使うことを推奨
     pub fn new(
         gl: Gl,
@@ -49,7 +51,7 @@ impl<'a> Vao<'a> {
         stride: GLsizei,
         vertex_num: i32,
         config: &'a VaoConfig,
-    ) -> Vao<'a> {
+    ) -> Self {
         debug_assert_eq!(num_attributes, attribute_types.len());
         debug_assert_eq!(num_attributes, attribute_sizes.len());
 
@@ -94,6 +96,7 @@ impl<'a> Vao<'a> {
         }
     }
 
+    #[deprecated(note = "Use `crate::Renderer` instead", since = "0.0.8")]
     /// Use [`crate::Renderer`] instead
     pub fn draw(&self, _uniforms: &UniformVariables, draw_mode: GLenum) {
         unsafe {
@@ -129,6 +132,7 @@ impl<'a> Vao<'a> {
         }
     }
 
+    #[deprecated(note = "Use `crate::Renderer` instead", since = "0.0.8")]
     /// ポリゴンを描画する
     /// Use [`crate::Renderer`] instead
     pub fn draw_triangles(&self, uniforms: &UniformVariables) {

--- a/reverie-engine-opengl/src/vao/buffer.rs
+++ b/reverie-engine-opengl/src/vao/buffer.rs
@@ -60,8 +60,7 @@ impl<V: VertexType> VaoBuffer<V> {
 
     /// 頂点群を追加する
     ///
-    /// * `v` - 頂点の情報がフラットに繰り返される`Vec`。したがって`v.len()`は[`VERTEX_SIZE`]の倍数になる。
-    /// ※頂点情報の仕様については`[VERTEX_SIZE`]を参照
+    /// * `v` - 頂点の情報がフラットに繰り返される`Vec`。したがって`v.len()`は[`VERTEX_SIZE`]の倍数になる。※頂点情報の仕様については`[VERTEX_SIZE`]を参照
     pub fn append(&mut self, v: &mut Vec<f32>) {
         debug_assert_eq!(v.len() % self.vertex_size, 0);
         self.vertex_num += (v.len() / self.vertex_size) as i32;
@@ -83,12 +82,14 @@ impl<V: VertexType> VaoBuffer<V> {
     ///
     /// 少なくとも`additional_num_vertex`個の頂点が格納できるように確保する。
     pub fn reserve(&mut self, additional_num_vertex: usize) {
-        self.buffer.reserve(additional_num_vertex * self.vertex_size);
+        self.buffer
+            .reserve(additional_num_vertex * self.vertex_size);
     }
 
     /// 先頭の`num_vertex_to_preserve`個の頂点以外の頂点を削除する
     pub fn clear_preserving_first(&mut self, num_vertex_to_preserve: usize) {
-        self.buffer.truncate(num_vertex_to_preserve * self.vertex_size);
+        self.buffer
+            .truncate(num_vertex_to_preserve * self.vertex_size);
     }
 
     /// 現在のバッファの内容をもとに[`Vao`]を作る

--- a/reverie-engine-opengl/src/vao/buffer.rs
+++ b/reverie-engine-opengl/src/vao/buffer.rs
@@ -94,17 +94,19 @@ impl<V: VertexType> VaoBuffer<V> {
 
     /// 現在のバッファの内容をもとに[`Vao`]を作る
     pub fn build<'a>(&self, gl: &Gl, config: &'a VaoConfig) -> Vao<'a> {
-        Vao::new(
-            gl.clone(),
-            (self.buffer.len() * mem::size_of::<GLfloat>()) as _,
-            self.buffer.as_ptr() as _,
-            gl::STATIC_DRAW,
-            self.num_attributes,
-            self.attribute_types,
-            self.attribute_sizes,
-            ((3 + 3 + 2) * mem::size_of::<GLfloat>()) as _,
-            self.vertex_num,
-            config,
-        )
+        unsafe {
+            Vao::new(
+                gl.clone(),
+                (self.buffer.len() * mem::size_of::<GLfloat>()) as _,
+                self.buffer.as_ptr() as _,
+                gl::STATIC_DRAW,
+                self.num_attributes,
+                self.attribute_types,
+                self.attribute_sizes,
+                ((3 + 3 + 2) * mem::size_of::<GLfloat>()) as _,
+                self.vertex_num,
+                config,
+            )
+        }
     }
 }

--- a/reverie-engine-opengl/src/vao/config.rs
+++ b/reverie-engine-opengl/src/vao/config.rs
@@ -25,7 +25,7 @@ impl Default for VaoConfigBuilder {
 }
 
 impl VaoConfigBuilder {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             depth_test: true,
             blend: true,
@@ -34,7 +34,7 @@ impl VaoConfigBuilder {
         }
     }
 
-    pub fn build(self) -> VaoConfig {
+    pub const fn build(self) -> VaoConfig {
         VaoConfig {
             depth_test: self.depth_test,
             blend: self.blend,
@@ -43,22 +43,22 @@ impl VaoConfigBuilder {
         }
     }
 
-    pub fn depth_test(mut self, value: bool) -> Self {
+    pub const fn depth_test(mut self, value: bool) -> Self {
         self.depth_test = value;
         self
     }
 
-    pub fn blend(mut self, value: bool) -> Self {
+    pub const fn blend(mut self, value: bool) -> Self {
         self.blend = value;
         self
     }
 
-    pub fn wireframe(mut self, value: bool) -> Self {
+    pub const fn wireframe(mut self, value: bool) -> Self {
         self.wireframe = value;
         self
     }
 
-    pub fn culling(mut self, value: bool) -> Self {
+    pub const fn culling(mut self, value: bool) -> Self {
         self.culling = value;
         self
     }

--- a/reverie-engine-opengl/src/vao/renderer.rs
+++ b/reverie-engine-opengl/src/vao/renderer.rs
@@ -18,7 +18,7 @@ pub struct Phong3DRenderer {
 }
 
 impl Phong3DRenderer {
-    pub fn new(program: Program) -> Self {
+    pub const fn new(program: Program) -> Self {
         Self { program }
     }
 }
@@ -70,8 +70,10 @@ impl Renderer<&Phong3DRenderingInfo<'_>> for Phong3DRenderer {
                 c_str!("uMaterial.shininess"),
                 &Float(extra.phong.material_shininess),
             );
-            self.program
-                .set_uniform(c_str!("uLight.direction"), &Vector3(extra.phong.light_direction));
+            self.program.set_uniform(
+                c_str!("uLight.direction"),
+                &Vector3(extra.phong.light_direction),
+            );
             self.program
                 .set_uniform(c_str!("uLight.ambient"), &Vector3(extra.phong.ambient));
             self.program
@@ -98,12 +100,16 @@ pub struct Color3DRenderer {
 
 impl Color3DRenderer {
     pub fn new(gl: &Gl) -> Self {
-        let vert_shader =
-            Shader::from_vert_code(gl.clone(), c_str!(include_str!("../../resources/color3d.vert")))
-                .unwrap();
-        let frag_shader =
-            Shader::from_frag_code(gl.clone(), c_str!(include_str!("../../resources/color3d.frag")))
-                .unwrap();
+        let vert_shader = Shader::from_vert_code(
+            gl.clone(),
+            c_str!(include_str!("../../resources/color3d.vert")),
+        )
+        .unwrap();
+        let frag_shader = Shader::from_frag_code(
+            gl.clone(),
+            c_str!(include_str!("../../resources/color3d.frag")),
+        )
+        .unwrap();
         let program = Program::from_shaders(gl.clone(), &[vert_shader, frag_shader]).unwrap();
         Self { program }
     }

--- a/reverie-engine-opengl/src/window.rs
+++ b/reverie-engine-opengl/src/window.rs
@@ -71,15 +71,17 @@ impl Window {
 
     #[cfg(feature = "winit")]
     pub fn update(&mut self, gl: &Gl) {
-        self.should_stop = self.event_loop.process_event(&mut self.input, &self.window, gl);
+        self.should_stop = self
+            .event_loop
+            .process_event(&mut self.input, &self.window, gl);
     }
 
-    pub fn should_stop(&self) -> bool {
+    pub const fn should_stop(&self) -> bool {
         self.should_stop
     }
 
     #[cfg(feature = "winit")]
-    pub fn get_winit_window(&self) -> &winit::window::Window {
+    pub const fn get_winit_window(&self) -> &winit::window::Window {
         &self.window
     }
 

--- a/reverie-engine-opengl/src/window/builder.rs
+++ b/reverie-engine-opengl/src/window/builder.rs
@@ -8,7 +8,7 @@ pub struct WindowConfig {
 }
 
 impl WindowConfig {
-    pub(crate) fn new() -> Self {
+    pub(crate) const fn new() -> Self {
         Self {
             title: None,
             width: 800,
@@ -23,7 +23,7 @@ pub struct WindowBuilder {
 }
 
 impl WindowBuilder {
-    pub(crate) fn new() -> Self {
+    pub(crate) const fn new() -> Self {
         Self {
             config: WindowConfig::new(),
         }
@@ -34,13 +34,13 @@ impl WindowBuilder {
         self
     }
 
-    pub fn size(mut self, width: u32, height: u32) -> Self {
+    pub const fn size(mut self, width: u32, height: u32) -> Self {
         self.config.width = width;
         self.config.height = height;
         self
     }
 
-    pub fn maximize(mut self) -> Self {
+    pub const fn maximize(mut self) -> Self {
         self.config.maximize = true;
         self
     }

--- a/reverie-engine-opengl/src/window/input.rs
+++ b/reverie-engine-opengl/src/window/input.rs
@@ -4,7 +4,7 @@ use std::collections::HashSet;
 pub mod cursor;
 
 #[cfg(feature = "winit")]
-pub fn mouse_button_index(mouse_button: &winit::event::MouseButton) -> usize {
+pub const fn mouse_button_index(mouse_button: &winit::event::MouseButton) -> usize {
     match mouse_button {
         winit::event::MouseButton::Left => 0,
         winit::event::MouseButton::Right => 1,
@@ -14,7 +14,7 @@ pub fn mouse_button_index(mouse_button: &winit::event::MouseButton) -> usize {
 }
 
 #[cfg(feature = "winit")]
-pub fn mouse_button_index_3(mouse_button: &winit::event::MouseButton) -> Option<usize> {
+pub const fn mouse_button_index_3(mouse_button: &winit::event::MouseButton) -> Option<usize> {
     match mouse_button {
         winit::event::MouseButton::Left
         | winit::event::MouseButton::Right
@@ -139,17 +139,17 @@ impl Input {
     }
 
     #[cfg(feature = "winit")]
-    pub(crate) fn get_cursor_pos(&self) -> CursorPosition<DesktopOrigin> {
+    pub(crate) const fn get_cursor_pos(&self) -> CursorPosition<DesktopOrigin> {
         CursorPosition::new(self.cursor_x, self.cursor_y)
     }
 
     #[cfg(feature = "winit")]
-    pub(crate) fn get_cursor_delta(&self) -> (i32, i32) {
+    pub(crate) const fn get_cursor_delta(&self) -> (i32, i32) {
         (self.cursor_dx, self.cursor_dy)
     }
 
     #[cfg(feature = "winit")]
-    pub(crate) fn get_mouse_pressed(&self, index: usize) -> bool {
+    pub(crate) const fn get_mouse_pressed(&self, index: usize) -> bool {
         self.mouse_pressed[index]
     }
 

--- a/reverie-engine-opengl/src/window/input/cursor.rs
+++ b/reverie-engine-opengl/src/window/input/cursor.rs
@@ -8,7 +8,7 @@ pub struct CursorPosition<O> {
 }
 
 impl<O> CursorPosition<O> {
-    pub fn new(x: i32, y: i32) -> Self {
+    pub const fn new(x: i32, y: i32) -> Self {
         Self {
             x,
             y,
@@ -18,11 +18,15 @@ impl<O> CursorPosition<O> {
 }
 
 impl CursorPosition<DesktopOrigin> {
-    pub fn to_window_origin(&self, window_x: i32, window_y: i32) -> CursorPosition<WindowOrigin> {
+    pub const fn to_window_origin(
+        &self,
+        window_x: i32,
+        window_y: i32,
+    ) -> CursorPosition<WindowOrigin> {
         CursorPosition::<WindowOrigin>::new(self.x - window_x, self.y - window_y)
     }
 
-    pub fn to_window_center(
+    pub const fn to_window_center(
         &self,
         window_x: i32,
         window_y: i32,

--- a/reverie-util/src/math/macros.rs
+++ b/reverie-util/src/math/macros.rs
@@ -1,14 +1,14 @@
 macro_rules! derive_into {
     ($target:ty, $into:ty) => {
-        impl<'a> Into<$into> for &'a $target {
-            fn into(self) -> $into {
-                self.0
+        impl<'a> From<&'a $target> for $into {
+            fn from(value: &'a $target) -> $into {
+                value.0
             }
         }
 
-        impl Into<$into> for $target {
-            fn into(self) -> $into {
-                self.0
+        impl From<$target> for $into {
+            fn from(value: $target) -> $into {
+                value.0
             }
         }
     };
@@ -92,7 +92,11 @@ macro_rules! derive_approx {
                 epsilon: Self::Epsilon,
                 max_relative: Self::Epsilon,
             ) -> bool {
-                <&Self as Into<$float>>::into(self).relative_eq(&other.into(), epsilon, max_relative)
+                <&Self as Into<$float>>::into(self).relative_eq(
+                    &other.into(),
+                    epsilon,
+                    max_relative,
+                )
             }
         }
 


### PR DESCRIPTION
- **refactor: use From impls**
- **refactor: add const**
- **refactor: add deprecated attributes**
- **refactor: disable clippy lint for generated code**
- **doc: update**
- **refactor: suppress warnings for missing safety doc**
- **feat!: make `Vao::new` unsafe because it may dereference unsafe pointer**
- **fix!: use simple type**
- **refactor: Self**
- **refactor: use std::iter::once**
- **refactor: justify unsafe pointer conversion**
- **refactor: const fn**
- **feat!: remove `Vao::new()`, `Vao::draw()`, and `Vao::draw_triangles()`.**
- **refactor: use unwrap_or_else**
- **refactor: allow too many args**
- **refactor: const fn**
- **refactor: fix INFINITY**
- **refactor: use map_or**
- **refactor: use slice**
- **refactor: remove unused lifetime**
